### PR TITLE
feat: Implement base LlmProvider trait and OpenAI provider (resolve #10)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1730,6 +1730,7 @@ dependencies = [
  "actix-web",
  "anyhow",
  "async-stripe",
+ "async-trait",
  "bcrypt",
  "chrono",
  "dotenv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ actix-rt = "2.10"
 
 # Async runtime
 tokio = { version = "1.38", features = ["full"] }
+async-trait = "0.1"
 
 # Database
 sqlx = { version = "0.8", features = ["postgres", "runtime-tokio-native-tls", "migrate"] }

--- a/src/handlers/ask.rs
+++ b/src/handlers/ask.rs
@@ -1,14 +1,14 @@
 //! Handler for the /ask LLM endpoint.
 
 use crate::models::{AskRequest, AskResponse};
-use crate::services::llm::OpenAiClient;
+use crate::services::llm::LlmProvider;
 use actix_web::{HttpResponse, web};
 use std::sync::Arc;
 
 /// Shared state for the ask endpoint
 #[derive(Clone)]
 pub struct AskState {
-    pub llm_client: Arc<OpenAiClient>,
+    pub llm_client: Arc<dyn LlmProvider>,
 }
 
 /// POST /ask handler

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod services;
 
 use actix_web::{App, HttpResponse, HttpServer, web};
 use handlers::AskState;
-use services::llm::OpenAiClient;
+use services::llm::{LlmProvider, OpenAiClient};
 use std::env;
 use std::sync::Arc;
 
@@ -48,15 +48,12 @@ async fn main() -> std::io::Result<()> {
 
     log::info!("Configuration: model={}, mock_mode={}", model, mock_mode);
 
-    // Create LLM client
-    // Use Arc because the OpenAiClient instance is shared by multiple actix-web
-    // worker threads and request handlers. Arc<T> provides thread-safe reference
-    // counting so we can clone cheap handles into app state without moving or
-    // copying the client. Do NOT use Rc<T> (not Send/Sync). If the client needs
-    // mutation, combine with Mutex/RwLock (e.g. Arc<Mutex<OpenAiClient>>).
-    // Note: actix_web::web::Data also wraps values in an Arc internally, so
-    // storing Arc<...> inside AskState is valid but a bit redundant.
-    let llm_client = Arc::new(OpenAiClient::new(api_key, model, mock_mode));
+    // Create LLM client using trait abstraction
+    // Use Arc<dyn LlmProvider> for dynamic dispatch with trait object
+    // This allows future swapping between different LLM providers (OpenAI, Gemini, etc.)
+    // Arc is required because the instance is shared by multiple actix-web
+    // worker threads and request handlers. Arc<T> provides thread-safe reference counting.
+    let llm_client: Arc<dyn LlmProvider> = Arc::new(OpenAiClient::new(api_key, model, mock_mode));
 
     // Create shared state
     let ask_state = web::Data::new(AskState {


### PR DESCRIPTION
## Summary

This PR implements: **Implement base LlmProvider trait and OpenAI provider**

- Resolves #10: Implement base LlmProvider trait and OpenAI provider
- Created from feature branch: `feature/task-10-implement-llm-provider-trait`

## Changes

- [x] Add `async-trait` dependency to `Cargo.toml`
- [x] Define `LlmProvider` trait with async `ask` method for LLM abstraction
- [x] Implement `LlmProvider` trait for `OpenAiClient`
- [x] Update `handlers/ask.rs` to use `Arc<dyn LlmProvider>`
- [x] Update `main.rs` to create `Arc<dyn LlmProvider>` with `OpenAiClient`
- [x] Enables future backend swaps (e.g., Gemini) and easier testing/mocking

## Validation

- ✅ Build validation: 100% PASS (`cargo build --release`)
- ✅ Clippy validation: 100% PASS (`cargo clippy --all-targets --all-features`)
- ✅ Format validation: 100% PASS (`cargo fmt -- --check`)
- ✅ Type check validation: 100% PASS (`cargo check`)
- ✅ Test validation: 100% PASS (`cargo test`)

## Test Plan

- [x] Build completes successfully with no errors
- [x] All clippy checks pass
- [x] Code formatting is consistent
- [x] Type system validates correctly
- [x] Integration tests pass (health_ok test)
- [x] Module imports resolve correctly

## Files Changed

- `Cargo.toml` (added async-trait dependency)
- `Cargo.lock` (updated dependencies)
- `src/services/llm/mod.rs` (trait definition + implementation)
- `src/handlers/ask.rs` (use trait abstraction)
- `src/main.rs` (use trait abstraction)

---

🤖 Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>